### PR TITLE
fix: chrome ext link

### DIFF
--- a/web/src/components/Connector/DownloadHelper.tsx
+++ b/web/src/components/Connector/DownloadHelper.tsx
@@ -35,6 +35,13 @@ export const DownloadHelper: React.FC<IDownloadHelperProps> = ({ size }) => {
                 >
                   Chrome 商店下载
                 </a>
+                <Divider type="vertical" />
+                <a
+                  href="https://opendocs.antchain.antgroup.com/myfish/dapp-connector"
+                  target="_blank"
+                >
+                  ZIP 包下载
+                </a>
               </>
             }
           />

--- a/web/src/components/Connector/DownloadHelper.tsx
+++ b/web/src/components/Connector/DownloadHelper.tsx
@@ -35,13 +35,6 @@ export const DownloadHelper: React.FC<IDownloadHelperProps> = ({ size }) => {
                 >
                   Chrome 商店下载
                 </a>
-                <Divider type="vertical" />
-                <a
-                  href="https://gw.alipayobjects.com/os/bmw-prod/36564bfb-36ff-48de-bde1-6bcfa600df2e.zip"
-                  target="_blank"
-                >
-                  ZIP 包下载
-                </a>
               </>
             }
           />

--- a/web/src/components/Connector/DownloadHelper.tsx
+++ b/web/src/components/Connector/DownloadHelper.tsx
@@ -30,7 +30,7 @@ export const DownloadHelper: React.FC<IDownloadHelperProps> = ({ size }) => {
             extra={
               <>
                 <a
-                  href="https://chrome.google.com/webstore/detail/%E8%9A%82%E8%9A%81%E9%93%BE%E8%BF%9E%E6%8E%A5%E5%99%A8/kcdkngkgoiaflfiofeecmhgnnicafkbg"
+                  href="https://chrome.google.com/webstore/detail/%E8%9A%82%E8%9A%81%E9%93%BE%E8%BF%9E%E6%8E%A5%E5%99%A8/ebmdohapebmbddpncmgehmocbbfoegjm"
                   target="_blank"
                 >
                   Chrome 商店下载


### PR DESCRIPTION
- 更新 chrome 插件地址
- zip 下载地址改为文档地址，这样才能保证最新，不然还要维护这个地址